### PR TITLE
[LRN] Tweaks for chemistry

### DIFF
--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -114,6 +114,15 @@ case '!':
   return Symbol('\\! ','<span style="margin-right:-.2em"></span>');
 */
 
+/**
+ * Horizontally stretched arrows.
+ */
+var LongArrow = P(Symbol, function(_, super_) {
+  _.init = function(ch, html) {
+    super_.init.call(this, ch, '<span class="mq-scaled mq-longarrow">'+html+'</span>');
+  };
+});
+
 //binary operators
 LatexCmds.diamond = bind(VanillaSymbol, '\\diamond ', '&#9671;');
 LatexCmds.bigtriangleup = bind(VanillaSymbol, '\\bigtriangleup ', '&#9651;');
@@ -155,13 +164,13 @@ LatexCmds.vdash = bind(VanillaSymbol, '\\vdash ', '&#8870;');
 LatexCmds.dashv = bind(VanillaSymbol, '\\dashv ', '&#8867;');
 
 //arrows
-LatexCmds.longleftarrow = bind(VanillaSymbol, '\\longleftarrow ', '&#8592;');
-LatexCmds.longrightarrow = bind(VanillaSymbol, '\\longrightarrow ', '&#8594;');
-LatexCmds.Longleftarrow = bind(VanillaSymbol, '\\Longleftarrow ', '&#8656;');
-LatexCmds.Longrightarrow = bind(VanillaSymbol, '\\Longrightarrow ', '&#8658;');
-LatexCmds.longleftrightarrow = bind(VanillaSymbol, '\\longleftrightarrow ', '&#8596;');
+LatexCmds.longleftarrow = bind(LongArrow, '\\longleftarrow ', '&#8592;');
+LatexCmds.longrightarrow = bind(LongArrow, '\\longrightarrow ', '&#8594;');
+LatexCmds.Longleftarrow = bind(LongArrow, '\\Longleftarrow ', '&#8656;');
+LatexCmds.Longrightarrow = bind(LongArrow, '\\Longrightarrow ', '&#8658;');
+LatexCmds.longleftrightarrow = bind(LongArrow, '\\longleftrightarrow ', '&#8596;');
+LatexCmds.Longleftrightarrow = bind(LongArrow, '\\Longleftrightarrow ', '&#8660;');
 LatexCmds.updownarrow = bind(VanillaSymbol, '\\updownarrow ', '&#8597;');
-LatexCmds.Longleftrightarrow = bind(VanillaSymbol, '\\Longleftrightarrow ', '&#8660;');
 LatexCmds.Updownarrow = bind(VanillaSymbol, '\\Updownarrow ', '&#8661;');
 LatexCmds.mapsto = bind(VanillaSymbol, '\\mapsto ', '&#8614;');
 LatexCmds.nearrow = bind(VanillaSymbol, '\\nearrow ', '&#8599;');
@@ -173,6 +182,7 @@ LatexCmds.rightharpoonup = bind(VanillaSymbol, '\\rightharpoonup ', '&#8640;');
 LatexCmds.swarrow = bind(VanillaSymbol, '\\swarrow ', '&#8601;');
 LatexCmds.leftharpoondown = bind(VanillaSymbol, '\\leftharpoondown ', '&#8637;');
 LatexCmds.rightharpoondown = bind(VanillaSymbol, '\\rightharpoondown ', '&#8641;');
+LatexCmds.rightleftharpoons = bind(VanillaSymbol, '\\rightleftharpoons ', '&#8652;');
 LatexCmds.nwarrow = bind(VanillaSymbol, '\\nwarrow ', '&#8598;');
 
 //Misc

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -404,7 +404,7 @@ LatexCmds['±'] = LatexCmds.pm = LatexCmds.plusmn = LatexCmds.plusminus =
 LatexCmds.mp = LatexCmds.mnplus = LatexCmds.minusplus =
   bind(PlusMinus,'\\mp ','&#8723;');
 
-CharCmds['*'] = LatexCmds.sdot = LatexCmds.cdot =
+CharCmds['*'] = LatexCmds.sdot = LatexCmds.cdot = LatexCmds.cdotp =
   bind(BinaryOperator, '\\cdot ', '&middot;');
 //semantically should be &sdot;, but &middot; looks better
 

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -277,6 +277,15 @@
       left: -0.3em;
     }
   }
+  .mq-longarrow {
+    -moz-transform: scaleX(1.5);
+    -o-transform: scaleX(1.5);
+    -webkit-transform: scaleX(1.5);
+    -ms-transform: scaleX(1.5);
+    transform: scaleX(1.5);
+    margin-right: 0.2em;
+    margin-left: 0.2em;
+  }
 
   ////
   // operators


### PR DESCRIPTION
- add rightleftharpoons
- add cdotp (equal to cdot)
- elongate longleftrightarrow etc

See [QUES-502](https://learnosity.atlassian.net/browse/QUES-502) (Create symbols for chemistry formulas)