### PR TITLE
[LRN] Limit textBlock.fuseChildren to text nodes

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -179,7 +179,7 @@ var TextBlock = P(Node, function(_, super_) {
   function fuseChildren(self) {
     self.jQ[0].normalize();
 
-    var textPcDom = self.jQ[0].firstChild;
+    var textPcDom = self.jQ.contents().filter(function (i, el) { return el.nodeType === 3; })[0]
     var textPc = TextPiece(textPcDom.data);
     textPc.jQadd(textPcDom);
 

--- a/test/unit/text.test.js
+++ b/test/unit/text.test.js
@@ -53,4 +53,16 @@ suite('text', function() {
     ctrlr.moveRight();
     assertSplit(cursor.jQ, 'abc', null);
   });
+
+  test('does not change latex as the cursor moves around', function() {
+    var block = fromLatex('\\text{x}');
+    var ctrlr = Controller({ __options: 0 }, block);
+    var cursor = ctrlr.cursor.insAtRightEnd(block);
+
+    ctrlr.moveLeft();
+    ctrlr.moveLeft();
+    ctrlr.moveLeft();
+
+    assert.equal(block.latex(), '\\text{x}');
+  });
 });


### PR DESCRIPTION
Prevents it from trying to fuse the cursor span, causing an error.

This is an issue with mathquill dev - submitted an issue and a pull
request at https://github.com/mathquill/mathquill/issues/429

When/if this PR gets merged into dev, we should remove this commit and
rebase on top of dev.

LRN-4214