### PR TITLE
[LRN] Disable editing Integral with SupSub

### DIFF
--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -238,9 +238,27 @@ LatexCmds.muL = bind(VanillaSymbol, '\\muL ', 'µL');
 
 //various symbols
 
+Controller.open(function(_) {
+  this.onNotify(function(e) {
+    if (e === 'move' && this[R] && this[R].movingLeftOf) {
+      this[R].movingLeftOf(this);
+    }
+  });
+});
+
+var Integral = P(Symbol, function(_, super_) {
+  // Prevent the cursor from getting close to this symbol
+  _.moveTowards = function(dir, cursor) {
+    if (dir === R && this[R] instanceof SupSub) {
+      cursor.insAtDirEnd(L, this[R].ends[L]);
+    }
+    else super_.moveTowards.apply(this, arguments);
+  };
+});
+
 LatexCmds['∫'] =
 LatexCmds['int'] =
-LatexCmds.integral = bind(Symbol,'\\int ','<big>&int;</big>');
+LatexCmds.integral = bind(Integral,'\\int ','<big>&int;</big>');
 
 LatexCmds.caret = bind(VanillaSymbol,'\\text{^}','^');
 LatexCmds.underscore = bind(VanillaSymbol,'\\_','_');

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -405,6 +405,11 @@ var SupSub = P(MathCommand, function(_, super_) {
     }
     else super_.moveTowards.apply(this, arguments);
   };
+  _.movingLeftOf = function(cursor) {
+    if (this[L] instanceof Integral) {
+      cursor.insLeftOf(this[L]);
+    }
+  };
   _.deleteTowards = function(dir, cursor) {
     if (cursor.options.autoSubscriptNumerals && this.sub) {
       var cmd = this.sub.ends[-dir];

--- a/test/unit/SupSub.test.js
+++ b/test/unit/SupSub.test.js
@@ -124,6 +124,15 @@ suite('SupSub', function() {
     assert.equal(mq.latex(), 'x_b^{ac}');
   });
 
+  test('moving cursor around Integral / SupSub combination', function() {
+    mq.latex('\\int_{ }^{ }');
+    mq.keystroke('Left Left Left').typedText('x');
+    assert.equal(mq.latex(), 'x\\int_{ }^{ }');
+
+    mq.keystroke('Right').typedText('y');
+    assert.equal(mq.latex(), 'x\\int_y^{ }');
+  });
+
   suite('deleting', function() {
     test('backspacing out of and then re-typing subscript', function() {
       mq.latex('x_a^b');


### PR DESCRIPTION
Now it's not possible to move the cursor (with arrow keys) between the
int symbol and its supsub.

LRN-4819