### PR TITLE
[BUG] Recognise compound commands with \not

### DIFF
--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -31,7 +31,8 @@ LatexCmds.isin = LatexCmds['in'] = bind(BinaryOperator,'\\in ','&isin;');
 
 LatexCmds.ni = LatexCmds.contains = bind(BinaryOperator,'\\ni ','&ni;');
 
-LatexCmds.notni = LatexCmds.niton = LatexCmds.notcontains = LatexCmds.doesnotcontain =
+LatexCmds.notni = LatexCmds.niton = LatexCmds.notcontains =
+LatexCmds.doesnotcontain = CompoundCmds['\\not\\ni'] =
   bind(BinaryOperator,'\\not\\ni ','&#8716;');
 
 LatexCmds.sub = LatexCmds.subset = bind(BinaryOperator,'\\subset ','&sub;');
@@ -41,11 +42,13 @@ LatexCmds.sup = LatexCmds.supset = LatexCmds.superset =
 
 LatexCmds.nsub = LatexCmds.notsub =
 LatexCmds.nsubset = LatexCmds.notsubset =
+CompoundCmds['\\not\\subset'] =
   bind(BinaryOperator,'\\not\\subset ','&#8836;');
 
 LatexCmds.nsup = LatexCmds.notsup =
 LatexCmds.nsupset = LatexCmds.notsupset =
 LatexCmds.nsuperset = LatexCmds.notsuperset =
+CompoundCmds['\\not\\supset'] =
   bind(BinaryOperator,'\\not\\supset ','&#8837;');
 
 LatexCmds.sube = LatexCmds.subeq = LatexCmds.subsete = LatexCmds.subseteq =
@@ -60,6 +63,7 @@ LatexCmds.nsube = LatexCmds.nsubeq =
 LatexCmds.notsube = LatexCmds.notsubeq =
 LatexCmds.nsubsete = LatexCmds.nsubseteq =
 LatexCmds.notsubsete = LatexCmds.notsubseteq =
+CompoundCmds['\\not\\subseteq'] =
   bind(BinaryOperator,'\\not\\subseteq ','&#8840;');
 
 LatexCmds.nsupe = LatexCmds.nsupeq =
@@ -68,6 +72,7 @@ LatexCmds.nsupsete = LatexCmds.nsupseteq =
 LatexCmds.notsupsete = LatexCmds.notsupseteq =
 LatexCmds.nsupersete = LatexCmds.nsuperseteq =
 LatexCmds.notsupersete = LatexCmds.notsuperseteq =
+CompoundCmds['\\not\\supseteq'] =
   bind(BinaryOperator,'\\not\\supseteq ','&#8841;');
 
 

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -27,6 +27,12 @@ var latexMathParser = (function() {
   var variable = letter.map(function(c) { return Letter(c); });
   var symbol = regex(/^[^${}\\_^]/).map(function(c) { return VanillaSymbol(c); });
 
+  // Compound commands e.g. \not\subset
+  var compound = regex(/^\\not\\[a-z]+/).then(function(cmp) {
+    return CompoundCmds[cmp] && CompoundCmds[cmp]().parser() ||
+      fail('unknown compound command: '+cmp);
+  });
+
   var controlSequence =
     regex(/^[^\\a-eg-zA-Z]/) // hotfix #164; match MathBlock::write
     .or(string('\\').then(
@@ -59,7 +65,8 @@ var latexMathParser = (function() {
   ;
 
   var command =
-    controlSequence
+    compound
+    .or(controlSequence)
     .or(variable)
     .or(symbol)
     .or(unknown)

--- a/src/tree.js
+++ b/src/tree.js
@@ -367,4 +367,4 @@ var Fragment = P(function(_) {
  *
  * (Commands are all subclasses of Node.)
  */
-var LatexCmds = {}, CharCmds = {};
+var LatexCmds = {}, CharCmds = {}, CompoundCmds = {};

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -113,6 +113,14 @@ suite('latex', function() {
     assertParsesLatex('\\begin{Vmatrix}x&y\\\\1\\end{Vmatrix}', '\\begin{Vmatrix}x&y\\\\1&\\end{Vmatrix}');
   });
 
+  test('compound symbols beginning with \\not', function() {
+    assertParsesLatex('\\not\\ni ');
+    assertParsesLatex('\\not\\subset ');
+    assertParsesLatex('\\not\\supset ');
+    assertParsesLatex('\\not\\subseteq ');
+    assertParsesLatex('\\not\\supseteq ');
+  });
+
   test('miscellaneous symbols', function() {
     assertParsesLatex('\\xrightarrow{xyz}');
     assertParsesLatex('\\xleftarrow{123}');


### PR DESCRIPTION
See problem discussion in LRN-5456 description.

The solution is to keep track of all compound commands using a new object `CompoundCmds`. Then during parsing, we check for compound commands before ordinary commands. This way `\not` will still work by itself even though we now recognise `\not\subset` as a separate symbol.