### PR TITLE
[LRN] Fixed bug when output LaTex of \lrnexponent was different than …

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -808,7 +808,10 @@ LatexCmds.lrnexponent = P(MathCommand, function(_, super_) {
   ;
   _.textTemplate = ['', '**'];
   _.latex = function() {
-    return this.ends[L].latex()+'^'+this.ends[R].latex();
+    var rLatex = this.ends[R].latex();
+    if (rLatex.length > 1) rLatex = '{'+rLatex+'}';
+    else if (rLatex.length === 0) rLatex = '{ }';
+    return this.ends[L].latex()+'^'+rLatex;
   };
 });
 

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -129,6 +129,8 @@ suite('latex', function() {
     assertParsesLatex('\\lrncuberoot{a}', '\\sqrt[3]{a}');
     assertParsesLatex('\\lrnplaceholder{a}', 'a');
     assertParsesLatex('\\lrnexponent{a}{b}', 'a^b');
+    assertParsesLatex('\\lrnexponent{a}{}', 'a^{ }');
+    assertParsesLatex('\\lrnexponent{aa}{bb}', 'aa^{bb}');
     assertParsesLatex('\\lrnsquaredexponent{a}', 'a^2');
     assertParsesLatex('\\lrnsubscript{a}{b}', 'a_b');
     assertParsesLatex('\\longdiv{x}');


### PR DESCRIPTION
…regular exponent command
