### PR TITLE
[BUG] Fix issue with multiple cursors in fraction questions

### DIFF
--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -35,14 +35,8 @@ Controller.open(function(_) {
       }
 
       function mouseup(e) {
-        cursor.blink = blink;
-        if (!cursor.selection) {
-          if (ctrlr.editable) {
-            cursor.show();
-          }
-          else {
+        if (!cursor.selection && !ctrlr.editable) {
             textareaSpan.detach();
-          }
         }
 
         // delete the mouse handlers now that we're not dragging anymore
@@ -50,20 +44,31 @@ Controller.open(function(_) {
         $(e.target.ownerDocument).unbind('mousemove', docmousemove).unbind('mouseup', mouseup);
       }
 
-      if (ctrlr.blurred) {
-        if (!ctrlr.editable) rootjQ.prepend(textareaSpan);
-        textarea.focus();
-      }
-      e.preventDefault(); // doesn't work in IE≤8, but it's a one-line fix:
-      e.target.unselectable = true; // http://jsbin.com/yagekiji/1
-
-      // if textarea is not focusable so the controller should not look for
-      // the mq component and set cursor to it
-      if (!textarea.is(':focus')) {
+      //if user clicks outside a response area
+      //or on the fraction bar, then a mouse event is triggered
+      //at this point, textareaSpan has a default value
+      //but is not attached to the DOM so has no parent
+      if (textareaSpan.parent().length === 0) {
         return false;
       }
+      
+      if (ctrlr.blurred) {
+        if (!ctrlr.editable) 
+          rootjQ.prepend(textareaSpan);
 
-      cursor.blink = noop;
+        //focus on body first
+        //to ensure that if user clicks in address
+        //bar and then back into a math box, the user can type
+        //otherwise, typing in the math box will just
+        //result in text being added to address bar
+        document.body.focus();
+        textarea.focus();
+      }
+
+      e.preventDefault(); // doesn't work in IE\u22648, but it's a one-line fix:
+      e.target.unselectable = true; // http://jsbin.com/yagekiji/1
+
+      cursor.show();
       ctrlr.seek($(e.target), e.pageX, e.pageY).cursor.startSelection();
 
       rootjQ.mousemove(mousemove);
@@ -73,7 +78,6 @@ Controller.open(function(_) {
     });
   }
 });
-
 Controller.open(function(_) {
   _.seek = function(target, pageX, pageY) {
     var cursor = this.notify('select').cursor;

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -129,6 +129,14 @@ suite('Public API', function() {
       assert.equal(textarea.hasClass('lrn_focusable'), true);
       assert.equal(textarea.attr('id'), id);
     });
+
+    test('mousedown outside editable area doesnt activate cursor', function() {
+      mq.latex('\\MathQuillMathField{}+\\MathQuillMathField{}');
+      $(mq.el()).find('.mq-binary-operator').trigger('mousedown');
+      assert.equal($(mq.el()).find('.mq-cursor').length, 0,
+        'Cursor was created outside editable areas');
+    });
+    
   });
 
   suite('basic API methods', function() {


### PR DESCRIPTION
- handle clicking in address bar and back again in IE11
- make sure there's only one cursor if user clicks between
  two fraction boxes

LRN-4969