### PR TITLE
[LRN] Keep xarrows vertically centered

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -74,7 +74,13 @@ var Style = P(MathCommand, function(_, super_) {
 var XArrowStyle = P(MathCommand, function(_, super_) {
   _.init = function(ctrlSeq, tagName, attrs) {
     this.args = arguments;
-    super_.init.call(this, ctrlSeq, '<'+tagName+' '+attrs+'><'+tagName+' class="mq-xarrow-over">&0</'+tagName+'></'+tagName+'>');
+    this.htmlTemplate =
+        '<' + tagName + ' ' + attrs + '>'
+      +   '<' + tagName + ' class="mq-xarrow-over">&0</' + tagName + '>'
+      +   '<' + tagName + ' class="mq-xarrow-under"></' + tagName + '>'
+      + '</' + tagName + '>'
+    ;
+    super_.init.call(this, ctrlSeq);
     this.textTemplate = [ctrlSeq.replace('\\', '') + '(', ')'];
   };
   _.parser = function() {
@@ -107,7 +113,6 @@ var XArrowWithSub = P(XArrowStyle, function(_, super_) {
     return this.ctrlSeq + '['+this.ends[L].latex()+']{'+this.ends[R].latex()+'}';
   };
   _.finalizeTree = function() {
-    this.jQ.addClass('mq-withsub');
     this.downInto = this.ends[L].upOutOf = this.ends[R];
     this.upInto = this.ends[R].downOutOf = this.ends[L];
   };

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -243,10 +243,7 @@
     font-size: 70%;
     text-align: center;
     padding: 0 0.2em;
-
-    &.mq-withsub {
-      vertical-align: 0.9em;
-    }
+    vertical-align: 0.9em;
 
     .mq-xarrow-over {
       border-bottom: 1px solid black;
@@ -268,7 +265,7 @@
       position: absolute;
       font-size: 0.6em;
       height: 1em;
-      bottom: -0.64em;
+      bottom: -0.62em;
       content: '\27A4';
       right: -0.3em;
     }


### PR DESCRIPTION
Regardless of whether they have the (optional) subscript or not.
Affects xrightarrow and xleftarrow.

LRN-6965