### PR TITLE
[LRN] Add maxDepth option for all input methods

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -26,6 +26,43 @@ var MathElement = P(Node, function(_, super_) {
     if (self[L].siblingCreated) self[L].siblingCreated(options, R);
     self.bubble('reflow');
   };
+  // If the maxDepth option is set, make sure
+  // deeply nested content is truncated. Just return
+  // false if the cursor is already too deep.
+  _.prepareInsertionAt = function(cursor) {
+    var maxDepth = cursor.options.maxDepth;
+    if (maxDepth !== undefined) {
+      var cursorDepth = cursor.depth();
+      if (cursorDepth > maxDepth) {
+        return false;
+      }
+      this.removeNodesDeeperThan(maxDepth-cursorDepth);
+    }
+    return true;
+  };
+  // Remove nodes that are more than `cutoff`
+  // blocks deep from this node.
+  _.removeNodesDeeperThan = function (cutoff) {
+    var depth = 0;
+    var queue = [[this, depth]];
+    var current;
+
+    // Do a breadth-first search of this node's descendants
+    // down to cutoff, removing anything deeper.
+    while (queue.length) {
+      current = queue.shift();
+      current[0].children().each(function (child) {
+        var i = (child instanceof MathBlock) ? 1 : 0;
+        depth = current[1]+i;
+
+        if (depth <= cutoff) {
+          queue.push([child, depth]);
+        } else {
+          (i ? child.children() : child).remove();
+        }
+      });
+    }
+  };
 });
 
 /**
@@ -409,12 +446,11 @@ var MathBlock = P(MathElement, function(_, super_) {
       return VanillaSymbol(ch);
   };
   _.write = function(cursor, ch) {
-    var cmd;
-    // preventing creating too many nested symbols
-    if (cursor.tooDeep()) return false;
-    cmd = this.chToCmd(ch, cursor.options);
+    var cmd = this.chToCmd(ch, cursor.options);
     if (cursor.selection) cmd.replaces(cursor.replaceSelection());
-    cmd.createLeftOf(cursor.show());
+    if (!cursor.isTooDeep()) {
+      cmd.createLeftOf(cursor.show());
+    }
   };
 
   _.focus = function() {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -682,7 +682,7 @@ CharCmds['/'] = P(Fraction, function(_, super_) {
           leftward = leftward[R];
       }
 
-      if (leftward !== cursor[L]) {
+      if (leftward !== cursor[L] && !cursor.isTooDeep(1)) {
         this.replaces(Fragment(leftward[R] || cursor.parent.ends[L], cursor[L]));
         cursor[L] = leftward;
       }

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -255,14 +255,18 @@ var Cursor = P(Point, function(_) {
     }
     return seln;
   };
-  _.howDeep = function() {
-    var parents = 0, node = this;
-    while (node = node.parent) { parents++; }
-    return 1 + Math.floor(parents/2);
+  _.depth = function() {
+    var node = this;
+    var depth = 0;
+    while (node = node.parent) {
+      depth += (node instanceof MathBlock) ? 1 : 0;
+    }
+    return depth;
   };
-  _.tooDeep = function() {
-    var max = this.options.maxDepth;
-    return max && this.howDeep() > max;
+  _.isTooDeep = function(offset) {
+    if (this.options.maxDepth !== undefined) {
+      return this.depth() + (offset || 0) > this.options.maxDepth;
+    }
   };
 });
 

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -35,7 +35,7 @@ function APIFnFor(APIClass) {
   return APIFn;
 }
 
-var Options = P({ maxDepth: 100 }), optionProcessors = {};
+var Options = P(), optionProcessors = {};
 MathQuill.__options = Options.p;
 
 var AbstractMathQuill = P(function(_) {
@@ -148,12 +148,10 @@ var EditableField = MathQuill.EditableField = P(AbstractMathQuill, function(_) {
   };
   _.cmd = function(cmd) {
     var ctrlr = this.__controller.notify(), cursor = ctrlr.cursor;
-    if (/^\\[a-z]+$/i.test(cmd)) {
+    if (/^\\[a-z]+$/i.test(cmd) && !cursor.isTooDeep()) {
       cmd = cmd.slice(1);
       var klass = LatexCmds[cmd] || UnknownCmd;
       cmd = klass(cmd);
-      // preventing creating too many nested symbols
-      if (cursor.tooDeep()) return false;
       if (cursor.selection) cmd.replaces(cursor.replaceSelection());
       cmd.createLeftOf(cursor.show());
       // if (cmd instanceof UnknownCmd) /* TODO: API needs better error reporting */;

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -437,6 +437,32 @@ suite('Public API', function() {
     });
   });
 
+  suite('maxDepth option', function() {
+    setup(function() {
+      mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0], {
+        maxDepth: 1
+      });
+    });
+    teardown(function() {
+      $(mq.el()).remove();
+    });
+
+    test('prevents nested math input via .write() method', function() {
+      mq.write('1\\frac{\\frac{3}{3}}{2}');
+      assert.equal(mq.latex(), '1\\frac{ }{ }');
+    });
+
+    test('prevents nested math input via keyboard input', function() {
+      mq.cmd('/').write('x');
+      assert.equal(mq.latex(), '\\frac{ }{ }');
+    });
+
+    test('stops new fraction moving content into numerator', function() {
+      mq.write('x').cmd('/');
+      assert.equal(mq.latex(), 'x\\frac{ }{ }');
+    });
+  });
+
   suite('statelessClipboard option', function() {
     suite('default', function() {
       var mq, textarea;

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1007,17 +1007,6 @@ suite('typing with auto-replaces', function() {
     });
   });
 
-  suite('max depth option', function() {
-    setup(function() {
-      mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0], { maxDepth: 2 });
-    });
-
-    test('quietly refuses to enter math deeper than maxDepth', function(){
-      mq.typedText('\\sqrt \\sqrt \\sqrt \\sqrt x');
-      assertLatex('\\sqrt{\\ \\sqrt{ }}');
-    });
-  });
-
   suite('polyatomic SupSub', function() {
     var valid = ['x_x{}^y', 'x_{ }{}^{ }', 'x_{x+123}{}^y', 'x_x{}^{y+123}', 'x_{x+123}{}^y'];
 


### PR DESCRIPTION
Removed the previous maxDepth implementation which only affected math
entered via typing. We now limit depth of math input from init, paste,
and public methods too.

See https://github.com/mathquill/mathquill/pull/654
LRN-13880