### PR TITLE
Support for 'leftRightIntoCmdGoes' config in the matrix element

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -105,6 +105,9 @@ var MathCommand = P(MathElement, function(_, super_) {
   // the cursor
   _.moveTowards = function(dir, cursor, updown) {
     var updownInto = updown && this[updown+'Into'];
+    if (typeof updownInto === 'function') {
+      updownInto = updownInto.call(this, dir, cursor);
+    }
     cursor.insAtDirEnd(-dir, updownInto || this.ends[-dir]);
   };
   _.deleteTowards = function(dir, cursor) {
@@ -377,6 +380,9 @@ var MathBlock = P(MathElement, function(_, super_) {
   // the cursor
   _.moveOutOf = function(dir, cursor, updown) {
     var updownInto = updown && this.parent[updown+'Into'];
+    if (typeof updownInto === 'function') {
+      updownInto = updownInto.call(this.parent, dir, cursor);
+    }
     if (!updownInto && this[dir]) cursor.insAtDirEnd(-dir, this[dir]);
     else cursor.insDirOf(dir, this.parent);
   };

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -105,9 +105,6 @@ var MathCommand = P(MathElement, function(_, super_) {
   // the cursor
   _.moveTowards = function(dir, cursor, updown) {
     var updownInto = updown && this[updown+'Into'];
-    if (typeof updownInto === 'function') {
-      updownInto = updownInto.call(this, dir, cursor);
-    }
     cursor.insAtDirEnd(-dir, updownInto || this.ends[-dir]);
   };
   _.deleteTowards = function(dir, cursor) {
@@ -380,9 +377,6 @@ var MathBlock = P(MathElement, function(_, super_) {
   // the cursor
   _.moveOutOf = function(dir, cursor, updown) {
     var updownInto = updown && this.parent[updown+'Into'];
-    if (typeof updownInto === 'function') {
-      updownInto = updownInto.call(this.parent, dir, cursor);
-    }
     if (!updownInto && this[dir]) cursor.insAtDirEnd(-dir, this[dir]);
     else cursor.insDirOf(dir, this.parent);
   };

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -1009,10 +1009,9 @@ Environments.matrix = P(Environment, function(_, super_) {
   };
   // Enter the matrix at the top or bottom row if updown is configured.
   _.getEntryPoint = function(dir, cursor, updown) {
-    var rowSize = this.getRowSize();
     if (updown === 'up') {
       if (dir === L) {
-        return this.blocks[rowSize - 1];
+        return this.blocks[this.rowSize - 1];
       } else {
         return this.blocks[0];
       }
@@ -1021,7 +1020,7 @@ Environments.matrix = P(Environment, function(_, super_) {
       if (dir === L) {
         return this.blocks[this.blocks.length - 1];
       } else {
-        return this.blocks[this.blocks.length - rowSize];
+        return this.blocks[this.blocks.length - this.rowSize];
       }
     } else {
       pray("Invalid value for updown '" + updown + "'", false);
@@ -1029,15 +1028,14 @@ Environments.matrix = P(Environment, function(_, super_) {
   };
   // Exit the matrix at the first and last columns if updown is configured.
   _.atExitPoint = function(dir, cursor) {
-      var rowSize = this.getRowSize();
       // Which block are we in?
       var i = this.blocks.indexOf(cursor.parent);
       if (dir === L) {
         // If we're on the left edge and moving left, we should exit.
-        return i % rowSize === 0;
+        return i % this.rowSize === 0;
       } else {
         // If we're on the right edge and moving right, we should exit.
-        return (i + 1) % rowSize == 0;
+        return (i + 1) % this.rowSize == 0;
       }
   };
   _.moveTowards = function(dir, cursor, updown) {
@@ -1045,22 +1043,15 @@ Environments.matrix = P(Environment, function(_, super_) {
     cursor.insAtDirEnd(-dir, entryPoint || this.ends[-dir]);
   };
 
-  _.getRowSize = function() {
-    var cell;
-    for (var i=0; i<this.blocks.length; i++) {
-      cell = this.blocks[i];
-      if (cell.row === 1) {
-        return i;
-      }
-    }
-    return this.blocks.length;
-  }
-
   // Set up directional pointers between cells
   _.relink = function() {
     var blocks = this.blocks;
     var rows = [];
     var row, column, cell;
+
+    // The row size will be used by other functions down the track.
+    // Begin by assuming we're a one-row matrix, and we'll overwrite this if we find another row.
+    this.rowSize = blocks.length;
 
     // Use a for loop rather than eachChild
     // as we're still making sure children()
@@ -1068,6 +1059,10 @@ Environments.matrix = P(Environment, function(_, super_) {
     for (var i=0; i<blocks.length; i+=1) {
       cell = blocks[i];
       if (row !== cell.row) {
+        if (cell.row === 1) {
+          // We've just finished iterating the first row.
+          this.rowSize = column;
+        }
         row = cell.row;
         rows[row] = [];
         column = 0;

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -1035,7 +1035,7 @@ Environments.matrix = P(Environment, function(_, super_) {
         return i % this.rowSize === 0;
       } else {
         // If we're on the right edge and moving right, we should exit.
-        return (i + 1) % this.rowSize == 0;
+        return (i + 1) % this.rowSize === 0;
       }
   };
   _.moveTowards = function(dir, cursor, updown) {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -1007,6 +1007,58 @@ Environments.matrix = P(Environment, function(_, super_) {
     table.toggleClass('mq-rows-1', table.find('tr').length === 1);
     this.relink();
   };
+  _.upInto = function(dir, cursor) {
+    var rowSize = this.getRowSize();
+    if (cursor.parent.parent === this) {
+      // We're inside the matrix.
+      var i = this.blocks.indexOf(cursor.parent);
+      if (dir === L) {
+        // If we're on the left edge and moving left, we should exit.
+        return i % rowSize === 0;
+      } else {
+        // If we're on the right edge and moving right, we should exit.
+        return (i + 1) % rowSize == 0;
+      }
+    }
+    // Otherwise, we must be about to enter the matrix.
+    if (dir === L) {
+      return this.blocks[rowSize - 1];
+    } else {
+      return this.blocks[0];
+    }
+  }
+  _.downInto = function(dir, cursor) {
+    var rowSize = this.getRowSize();
+    if (cursor.parent.parent === this) {
+      // We're inside the matrix.
+      var i = this.blocks.indexOf(cursor.parent);
+      if (dir === L) {
+        // If we're on the left edge and moving left, we should exit.
+        return i % rowSize === 0;
+      } else {
+        // If we're on the right edge and moving right, we should exit.
+        return (i + 1) % rowSize == 0;
+      }
+    }
+    // Otherwise, we must be about to enter the matrix.
+    if (dir === L) {
+      return this.blocks[this.blocks.length - 1];
+    } else {
+      return this.blocks[this.blocks.length - rowSize];
+    }
+  }
+
+  _.getRowSize = function() {
+    var cell;
+    for (var i=0; i<this.blocks.length; i++) {
+      cell = this.blocks[i];
+      if (cell.row === 1) {
+        return i;
+      }
+    }
+    return this.blocks.length;
+  }
+
   // Set up directional pointers between cells
   _.relink = function() {
     var blocks = this.blocks;

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -1015,15 +1015,12 @@ Environments.matrix = P(Environment, function(_, super_) {
       } else {
         return this.blocks[0];
       }
-    } else if (updown === 'down') {
-      // Otherwise, we must be about to enter the matrix.
+    } else { // updown === 'down'
       if (dir === L) {
         return this.blocks[this.blocks.length - 1];
       } else {
         return this.blocks[this.blocks.length - this.rowSize];
       }
-    } else {
-      pray("Invalid value for updown '" + updown + "'", false);
     }
   };
   // Exit the matrix at the first and last columns if updown is configured.

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1119,6 +1119,62 @@ suite('typing with auto-replaces', function() {
       assertLatex('\\begin{matrix}&&\\\\b&c&\\\\a&d&\\end{matrix}');
     });
 
+    test('passes over matrices when leftRightIntoCmdGoes is set to up', function() {
+      mq.config({ leftRightIntoCmdGoes: 'up' });
+
+      // 1 2 3
+      // 4 5 6
+      // 7 8 9
+      mq.write('\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8&9\\end{matrix}');
+
+      mq.keystroke('Left Left Left Left Left Left Left').typedText('a')
+        .keystroke('Right Right Right Right Right Right Right').typedText('b')
+        .keystroke('Left Left Left Left').typedText('c');
+
+      // It should've entered the top of the matrix and exited at either end, leading to
+      //   1  2c 3
+      // a 4  5  6 b
+      //   7  8  9
+      assertLatex('a\\begin{matrix}1&2c&3\\\\4&5&6\\\\7&8&9\\end{matrix}b');
+    });
+
+    test('passes under matrices when leftRightIntoCmdGoes is set to down', function() {
+      mq.config({ leftRightIntoCmdGoes: 'down' });
+
+      // 1 2 3
+      // 4 5 6
+      // 7 8 9
+      mq.write('\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8&9\\end{matrix}');
+
+      mq.keystroke('Left Left Left Left Left Left Left').typedText('a')
+        .keystroke('Right Right Right Right Right Right Right').typedText('b')
+        .keystroke('Left Left Left Left').typedText('c');
+
+      // It should've entered the bottom of the matrix and exited at either end, leading to
+      //   1  2  3
+      // a 4  5  6 b
+      //   7  8c 9
+      assertLatex('a\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8c&9\\end{matrix}b');
+    });
+
+    test('exits out of matrices on their edges when leftRightIntoCmdGoes is set', function() {
+      mq.config({ leftRightIntoCmdGoes: 'up' });
+
+      // 1 2 3
+      // 4 5 6
+      // 7 8 9
+      mq.write('\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8&9\\end{matrix}');
+
+      mq.keystroke('Left Left Left Down').typedText('a')
+        .keystroke('Right Right Right').typedText('b')
+
+      // It should've entered the top of the matrix and exited out the side, leading to
+      // 1  2  3
+      // 4  5a 6 b
+      // 7  8  9
+      assertLatex('\\begin{matrix}1&2&3\\\\4&5a&6\\\\7&8&9\\end{matrix}b');
+    });
+
     test('delete key removes empty matrix row/column', function() {
       mq.write('\\begin{matrix}a&&b\\\\&c&d\\\\&e&f\\end{matrix}');
 


### PR DESCRIPTION
This lets the user cross over the top or bottom of the matrix naturally
without getting caught inside it, using the same config option as for
fractions.

`leftRightIntoCmdGoes: "up"`
![leftrightintocmdgoesup](https://user-images.githubusercontent.com/2832017/28105921-0841047e-6725-11e7-8df3-afd1d5de7584.gif)
`leftRightIntoCmdGoes: "down"`
![leftrightintocmdgoesdown](https://user-images.githubusercontent.com/2832017/28105923-0cf48338-6725-11e7-9c80-91b986cc2bc9.gif)
