### PR TITLE
[LRN] Prevent nesting limit workaround

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -115,6 +115,8 @@ var MathCommand = P(MathElement, function(_, super_) {
     if (replacedFragment) {
       replacedFragment.adopt(cmd.ends[L], 0, 0);
       replacedFragment.jQ.appendTo(cmd.ends[L].jQ);
+      cmd.placeCursor(cursor);
+      cmd.prepareInsertionAt(cursor);
     }
     cmd.finalizeInsert(cursor.options);
     cmd.placeCursor(cursor);

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -461,6 +461,11 @@ suite('Public API', function() {
       mq.write('x').cmd('/');
       assert.equal(mq.latex(), 'x\\frac{ }{ }');
     });
+
+    test('prevents nested math input via replacedFragment', function() {
+      mq.cmd('(').keystroke('Left').cmd('(')
+      assert.equal(mq.latex(), '\\left(\\right)');
+    });
   });
 
   suite('statelessClipboard option', function() {


### PR DESCRIPTION
Fixes a bug where it's possible to defeat the nesting limit by adding
a bracket (or other enclosing element) before nested content, thus
wrapping the content and increasing its nesting depth each time.

LRN-16925