### PR TITLE
Change align environment cell alignment order

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -945,9 +945,6 @@ Environments.matrix = P(Environment, function(_, super_) {
         trs += '<tr>$tds</tr>';
         cells[row] = [];
       }
-      if (this.parent.htmlColumnSeparator && !isFirstColumn) {
-        cells[row].push(this.parent.htmlColumnSeparator);
-      }
       cells[row].push('<td>&'+(i++)+'</td>');
     });
 
@@ -1204,9 +1201,6 @@ Environments.matrix = P(Environment, function(_, super_) {
       block = MatrixCell(row+1);
       block.parent = this;
       newCells.push(block);
-      if (this.htmlColumnSeparator && !isFirstColumn) {
-        newRow.append($(this.htmlColumnSeparator));
-      }
       isFirstColumn = false;
       // Create cell <td>s and add to new row
       block.jQ = $('<td class="mq-empty">')
@@ -1323,50 +1317,13 @@ Environments.Vmatrix = P(Matrix, function(_, super_) {
 // differently in latex. Nevertheless, we want it to render as a table so it's convenient to extend Matrix.
 Environments['align*'] = P(Matrix, function (_, super_) {
   _.environment = 'align*';
-  _.extraTableClasses = 'mq-rcl';
+  _.extraTableClasses = 'mq-align';
   _.createBlocks = function() {
     this.blocks = [
       MatrixCell(0, this),
       MatrixCell(0, this),
     ];
   }
-  _.htmlColumnSeparator = '<td class="mq-align-equal">=</td>';
-  _.delimiters = {
-    column: '&=',
-    row: '\\\\',
-  };
-
-  // Don't delete empty columns, the align environment is for equations and should always have two columns.
-  _.removeEmptyColumns = false;
-
-  // For the same reason, don't allow adding columns.
-  _.addColumn = function() {};
-
-  // jQadd hack to keep the cursor in the correct row on seek
-  _.jQadd = function(jQ) {
-    var cmd = this, eachChild = this.eachChild;
-    jQ = super_.jQadd.call(this, jQ);
-
-    // Listen for mousedown on td.mq-align-equal descendants
-    // Handler will run just before `this.seek` is triggered by a similar
-    // listener in the controller.
-    jQ.delegate('td.mq-align-equal', 'mousedown.mathquill.alignenv', function (e) {
-      var tds = $(e.currentTarget).siblings('td');
-      var row = Fragment(
-        Node.byId[tds[0].getAttribute(mqBlockId)],
-        Node.byId[tds[1].getAttribute(mqBlockId)]
-      );
-
-      // Temporarily monkey-patch eachChild so that seek is limited
-      // to this row only.
-      // TODO - fix this properly
-      cmd.eachChild = function() {
-        row.each.apply(row, arguments);
-        cmd.eachChild = eachChild;
-      };
-    });
-    return jQ;
-  };
 });
 
 // Replacement for mathblocks inside matrix cells

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -389,14 +389,11 @@
         margin-bottom: 1px;
       }
 
-      &.mq-rcl {
-        td:nth-child(1) {
+      &.mq-align {
+        td:nth-child(odd) {
           text-align: right;
         }
-        td:nth-child(2) {
-          text-align: center;
-        }
-        td:nth-child(3) {
+        td:nth-child(even) {
           text-align: left;
         }
       }

--- a/test/visual.html
+++ b/test/visual.html
@@ -290,21 +290,35 @@ x+\class{testclass}{y}+z
 <p>Mutiple consecutive spaces in the middle of a text mode block should not collapse into one space: <span class="mathquill-static-math">\text{three   spaces}</span></p>
 
 <h3>Matrix align* environments</h3>
-<p>align* environments should render with each row's = sign aligned, the LHS aligned right, and the RHS aligned left
+<p>align* environments should render in a similar manner to matrix environments, except their cell alignment occurs in the order {rlrlrlrl...}</p>
+    <span class="mathquill-static-math">
+        \begin{align*}
+\frac{3x + y}{7} &amp;&amp;= 9  &amp;&amp; \text{given}   \\
+3x + y &amp;&amp;= 63           &amp;&amp; \text{multiply by 7}   \\
+3x &amp;&amp;= 63 - y           &amp;&amp; \text{subtract y}   \\
+x &amp;&amp;= 21 - \frac{y}{3}  &amp;&amp; \text{divide by 3}   \\
+\end{align*}
+    </span>
+<p>They can align on any symbol prefixed by an &amp;</p>
+<span class="mathquill-static-math">
+    \begin{align*}
+ f(x) &amp;= x^4 + 7x^3 + 2x^2 \\
+      &amp;+ 10x + 12
+\end{align*}
+</span>
+<p>They may also have multiple equations per line</p>
   <span class="mathquill-static-math">
     \begin{align*}
-                  y &amp;= mx+c \\
-               y-c  &amp;= mx   \\
-      \frac{y-c}{m} &amp;= x
-    \end{align*}
+ f(x)  &amp;= a x^2+b x +c   &amp;   g(x)  &amp;= d x^3 \\
+ f'(x) &amp;= 2 a x +b       &amp;   g'(x) &amp;= 3 d x^2
+\end{align*}
   </span>
   </p>align* environments can be edited. New row: shift+enter.<p>
   <span class="mathquill-math-field">
-    \begin{align*}
-                  y &amp;= mx+c \\
-               y-c  &amp;= mx   \\
-      \frac{y-c}{m} &amp;= x
-    \end{align*}
+      \begin{align*}
+      f(x) &amp;= (x+a)(x+b) \\
+           &amp;= x^2 + (a+b)x + ab
+     \end{align*}
   </span>
 </p>
 


### PR DESCRIPTION
I have been looking at the great work happening in the `matrix` and `align` branches here and thought we could make some slight improvements to the way this works?

AFAIK, the cells in an align environment are just ordered `{rlrlrl....}`, it doesn't create a centrally aligned cell for `=`.

I don't think `&=` is a special character which requires it's own parsing, it's just an `&` denoting a new cell and the first character in that cell is an `=`. In that way, if we assume an align === a matrix and change the CSS accordingly I think we can get some very accurate results (see updated `visual.html` tests). I've taken some samples from [Wikibooks](https://en.wikibooks.org/wiki/LaTeX/Advanced_Mathematics#align_and_align*) and other areas around the web.

These changes allow for multiple equations on one line, to be able to modify the alignment character and also to continue using Shift+Spacebar to add a new cell.