### PR TITLE
[LRN] Fix escaping of \MathQuillVarField commands

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -1243,11 +1243,9 @@ LatexCmds.MathQuillVarField = P(MathCommand, function(_, super_) {
     + '</span>'
   ;
   _.latex = function() {
-    return this.text();
+    return '{{var:' + this.ends[L].latex().replace(/\s|\\|operatorname\{|\}/g, '') + '}}';
   };
-  _.text = function() {
-    return '{{var:' + this.jQ.find('[mathquill-command-id]').text() + '}}';
-  };
+  _.text = function(){ return this.ends[L].text(); };
   _.finalizeTree = function() {
     var root = Node.byId[this.jQ.closest('.mq-root-block').attr(mqBlockId)],
     opts = root && root.controller && root.controller.API.__options || {};

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -1242,8 +1242,12 @@ LatexCmds.MathQuillVarField = P(MathCommand, function(_, super_) {
     +   '<span class="mq-root-block">&0</span>'
     + '</span>'
   ;
-  _.latex = function(){ return '{{var:' + this.ends[L].latex() + '}}'; };
-  _.text = function(){ return this.ends[L].text(); };
+  _.latex = function() {
+    return this.text();
+  };
+  _.text = function() {
+    return '{{var:' + this.jQ.find('[mathquill-command-id]').text() + '}}';
+  };
   _.finalizeTree = function() {
     var root = Node.byId[this.jQ.closest('.mq-root-block').attr(mqBlockId)],
     opts = root && root.controller && root.controller.API.__options || {};

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -297,6 +297,26 @@ suite('latex', function() {
     });
   });
 
+  suite('\\MathQuillVarField', function() {
+    var mq;
+    setup(function() {
+      mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+    });
+    teardown(function() {
+      $(mq.el()).remove();
+    });
+
+    test('.latex() returns var expression', function() {
+      mq.write('\\MathQuillVarField{using}');
+      assert.equal(mq.latex(), '{{var:using}}');
+    });
+
+    test('.text() returns var expression', function() {
+      mq.write('\\MathQuillVarField{using}');
+      assert.equal(mq.text(), '{{var:using}}');
+    });
+  });
+
   suite('error handling', function() {
     var mq;
     setup(function() {


### PR DESCRIPTION
This change resolves [LRN-19377](https://learnosity.atlassian.net/browse/LRN-19377).

When serialising a math expression via `mq.latex()`, a command such as `\MathQuillVarField{unaffected}` is formatted as `{{var:unaffected}}`, while `\MathQuillVarField{asinine}` is formatted as `{{var:a\sin ine}}`.

This is because the `MathQuillVarField` expression inherits from `MathCommand`, which is recursive, and causes MathQuill's parser to interprets all content inside the braces as math – i.e. `a * sin(i * n * e)`. This behaviour breaks dynamic content substitution when variables are added via the Authoring UI, as both api-questions and api-questioneditor rely on `mq.latex()` outputting well-formed var expressions.

The ideal fix for this would be to update the `MathQuillVarField` parser combinator to not treat its argument as math, but this change is likely to break several parts of our codebases that rely on MathQuill's specific behaviour and DOM. Instead, I've gone with the quick-fix of just changing `MathQuillVarField` serialisation, and leaving the DOM and incorrect parsing as-is.