### PR TITLE
[LRN] Fix vertical alignment of \sum expressions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "devDependencies": {
     "mocha": "*",
     "uglify-js": "2.x",
-    "less": ">=1.5.1",
+    "less": "2.7.2",
     "webdrivercss": "~1.1.3",
     "grunt": "~0.4.5",
     "load-grunt-tasks": "~3.1.0",

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -568,6 +568,7 @@
 
   .mq-large-operator {
     text-align: center;
+    vertical-align: middle;
 
     .mq-from, big, .mq-to  {
       display: block;


### PR DESCRIPTION
Firefox renders expressions such as `\sum_{i=1}^n1` differently to other browsers, by vertically aligning the `.mq-large-operator` containing the sigma to the baseline rather than the middle.

This change makes `.mq-large-operator` consistent with other large inline-block elements such as `.mq-matrix` by making its vertical-align explicit.